### PR TITLE
Fix typo in the __closely_associated_score computation

### DIFF
--- a/Automatic-Summarization/.idea/.gitignore
+++ b/Automatic-Summarization/.idea/.gitignore
@@ -1,0 +1,2 @@
+# Default ignored files
+/workspace.xml

--- a/Automatic-Summarization/.idea/Automatic-Summarization.iml
+++ b/Automatic-Summarization/.idea/Automatic-Summarization.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="projectConfiguration" value="pytest" />
+    <option name="PROJECT_TEST_RUNNER" value="pytest" />
+  </component>
+</module>

--- a/Automatic-Summarization/.idea/inspectionProfiles/profiles_settings.xml
+++ b/Automatic-Summarization/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/Automatic-Summarization/.idea/misc.xml
+++ b/Automatic-Summarization/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.7" project-jdk-type="Python SDK" />
+</project>

--- a/Automatic-Summarization/.idea/modules.xml
+++ b/Automatic-Summarization/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Automatic-Summarization.iml" filepath="$PROJECT_DIR$/.idea/Automatic-Summarization.iml" />
+    </modules>
+  </component>
+</project>

--- a/Automatic-Summarization/.idea/vcs.xml
+++ b/Automatic-Summarization/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/Automatic-Summarization/pysummarization/nlpbase/auto_abstractor.py
+++ b/Automatic-Summarization/pysummarization/nlpbase/auto_abstractor.py
@@ -156,6 +156,6 @@ class AutoAbstractor(NlpBase):
                 if score > max_cluster_score:
                     max_cluster_score = score
 
-            scores_list.append((sentence_idx, score))
+            scores_list.append((sentence_idx, max_cluster_score))
 
         return scores_list


### PR DESCRIPTION
In auto_abstractor.py and the method __closely_associated_score, return the max_cluster_score for each sentence instead of the score.