### PR TITLE
Fix typo in __closely_associated_score computation

### DIFF
--- a/Automatic-Summarization/pysummarization/nlpbase/auto_abstractor.py
+++ b/Automatic-Summarization/pysummarization/nlpbase/auto_abstractor.py
@@ -156,6 +156,6 @@ class AutoAbstractor(NlpBase):
                 if score > max_cluster_score:
                     max_cluster_score = score
 
-            scores_list.append((sentence_idx, score))
+            scores_list.append((sentence_idx, max_cluster_score))
 
         return scores_list


### PR DESCRIPTION
In auto_abstractor.py and the method __closely_associated_score, return the max_cluster_score for each sentence instead of the score.